### PR TITLE
set up testing framework

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ from ruby:2.5.1
 
 RUN apt-get update -qq && apt-get install -y build-essential libpq-dev curl
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+RUN dpkg -i google-chrome-stable_current_amd64.deb; apt-get -fy install
 RUN apt-get update && apt-get install -y nodejs
 RUN npm install yarn -g
 

--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ end
 group :test do
   # Adds support for Capybara system testing and selenium driver
   gem "capybara", ">= 2.15"
+  gem "capybara-selenium"
   gem "selenium-webdriver"
   # Easy installation and use of chromedriver to run system tests with Chrome
   gem "chromedriver-helper"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,9 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.2)
       xpath (~> 3.2)
+    capybara-selenium (0.0.6)
+      capybara
+      selenium-webdriver
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     chromedriver-helper (2.1.0)
@@ -232,6 +235,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   capybara (>= 2.15)
+  capybara-selenium
   chromedriver-helper
   coffee-rails (~> 4.2)
   jbuilder (~> 2.5)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ finally you can run the application as:
 # Testing the app
 * `docker-compose exec web bundle exec rspec <file name>` will test a specific file 
 * `docker-compose exec web bundle exec rspec` will test all files
+* Adding feature tests:
+    *   Follow existing convention, and add a tag to the example group like:
+        `describe "visit root", :type => feature do` which makes it a feature.
+    *   `rspec` runs both features and normal specs
+
 
 
 # Deploying to Production

--- a/spec/features/temporary_root_spec.rb
+++ b/spec/features/temporary_root_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+describe "visit root", :type => feature do
+  it 'shows the homepage' do
+    visit '/'
+    expect(true)
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,12 +1,32 @@
 # frozen_string_literal: true
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
-require "spec_helper"
 ENV["RAILS_ENV"] ||= "test"
 require File.expand_path("../config/environment", __dir__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
+
 require "rspec/rails"
+require "spec_helper"
+require "capybara/rspec"
+require "capybara/rails"
+require "selenium/webdriver"
+
+Capybara.register_driver :chrome do |app|
+  Capybara::Selenium::Driver.new(app, browser: :chrome)
+end
+
+Capybara.register_driver :headless_chrome do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+      chromeOptions: { args: %w(headless disable-gpu) }
+  )
+
+  Capybara::Selenium::Driver.new app,
+                                 browser: :chrome,
+                                 desired_capabilities: capabilities
+end
+
+Capybara.javascript_driver = :headless_chrome
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -60,4 +80,5 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.include Capybara::DSL
 end


### PR DESCRIPTION
This shows how we can set up acceptance tests. The drivers, packages, and configs are all updated and should run. There is a failing example test in place now.

The test tries to `visit '/'` however because the tests are running as `RAILS_ENV=TEST` this disables the rails welcome home page that you normally see when `RAILS_ENV=DEVELOPMENT`. That is why the test fails. When we add our first view, we can add our first real acceptance/integration test.